### PR TITLE
Support Python 3.x by using the use_2to3 option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
     entry_points="""
         [console_scripts]
         rst2ast = rst2ast.cmd:run
-    """
+    """,
+    use_2to3 = True
 )


### PR DESCRIPTION
This library does not support Python 3.x
because it uses `unicode` and `long` functions in `writer.py`.

Fix the problem by using the `use_2to3` option in `setup.py`.
