### PR TITLE
Remove use_2to3

### DIFF
--- a/rst2ast/writer.py
+++ b/rst2ast/writer.py
@@ -47,7 +47,7 @@ class ASTTranslator(nodes.GenericNodeVisitor):
         # Attributes
         for k, v in node.__dict__.items():
             try:
-                if not k.startswith('__') and isinstance(v, (str, int, float, bool, unicode, long,)):
+                if not k.startswith('__') and isinstance(v, (str, int, float, bool,)):
                     result[k] = v
             except NameError as e:
                 pass

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 setup(
     name='docutils-ast-writer',
     description='AST Writer for docutils',
-    version='0.1.2',
+    version='0.1.3',
     author='jimo1001',
     author_email='jimo1001@gmail.com',
     license='MIT',
@@ -19,5 +19,5 @@ setup(
         [console_scripts]
         rst2ast = rst2ast.cmd:run
     """,
-    use_2to3 = True
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
use_2to3 is no longer supported by setuptools. Let's deprecate Python 2
support, and remove the types `unicode` and `long`.

Closes 4